### PR TITLE
Fix:  修改达梦数据库的sql脚本

### DIFF
--- a/Dameng/single-no-schema/postgres_sys_Login.sql
+++ b/Dameng/single-no-schema/postgres_sys_Login.sql
@@ -11,7 +11,7 @@ comment on table "Login" is '登录信息';
 
 comment on column "Login"."id" is '唯一标识';
 
-comment on column "Login".""userId"" is '用户id';
+comment on column "Login".userId" is '用户id';
 
 comment on column "Login"."type" is '类型
 0-密码登录

--- a/Dameng/single-no-schema/postgres_sys_Request.sql
+++ b/Dameng/single-no-schema/postgres_sys_Request.sql
@@ -5,7 +5,7 @@ create table "Request"
     "method"    varchar(10),
     "tag"       varchar(20) not null,
     "structure" text       not null,
-    "detail"    varchar(10000),
+    "detail"    varchar(8000),
     "date"      timestamp(6)
 );
 


### PR DESCRIPTION
sql导入报错
1.修复Login表中双引号重复问题
2.修复Request表中detail字段超出达梦数据库长度限制问题